### PR TITLE
Agregar entidad tblPruebas

### DIFF
--- a/ProyectoCursoIA/Data/ApplicationDbContext.cs
+++ b/ProyectoCursoIA/Data/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using ProyectoCursoIA.Models;
 
 namespace ProyectoCursoIA.Data;
 
@@ -7,5 +8,30 @@ public class ApplicationDbContext : DbContext
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {
+    }
+
+    public DbSet<TblPrueba> TblPruebas => Set<TblPrueba>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<TblPrueba>(entity =>
+        {
+            entity.ToTable("tblPruebas");
+
+            entity.HasKey(e => e.ID);
+
+            entity.Property(e => e.ID)
+                .ValueGeneratedOnAdd();
+
+            entity.Property(e => e.Fecha)
+                .HasColumnType("datetime")
+                .HasDefaultValueSql("GETDATE()");
+
+            entity.Property(e => e.NumeroCel)
+                .HasMaxLength(10)
+                .IsUnicode(false);
+        });
     }
 }

--- a/ProyectoCursoIA/Migrations/20241006120000_CreateTblPruebas.cs
+++ b/ProyectoCursoIA/Migrations/20241006120000_CreateTblPruebas.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProyectoCursoIA.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateTblPruebas : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tblPruebas",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Fecha = table.Column<DateTime>(type: "datetime", nullable: false, defaultValueSql: "GETDATE()"),
+                    NumeroCel = table.Column<string>(type: "varchar(10)", unicode: false, maxLength: 10, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tblPruebas", x => x.ID);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tblPruebas");
+        }
+    }
+}

--- a/ProyectoCursoIA/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/ProyectoCursoIA/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ProyectoCursoIA.Data;
+
+#nullable disable
+
+namespace ProyectoCursoIA.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "9.0.9")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("ProyectoCursoIA.Models.TblPrueba", b =>
+                {
+                    b.Property<int>("ID")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ID"));
+
+                    b.Property<DateTime>("Fecha")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime")
+                        .HasDefaultValueSql("GETDATE()");
+
+                    b.Property<string>("NumeroCel")
+                        .IsRequired()
+                        .HasMaxLength(10)
+                        .IsUnicode(false)
+                        .HasColumnType("varchar(10)");
+
+                    b.HasKey("ID");
+
+                    b.ToTable("tblPruebas");
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/ProyectoCursoIA/Models/TblPrueba.cs
+++ b/ProyectoCursoIA/Models/TblPrueba.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProyectoCursoIA.Models;
+
+public class TblPrueba
+{
+    public int ID { get; set; }
+
+    public DateTime Fecha { get; set; }
+
+    [StringLength(10)]
+    public required string NumeroCel { get; set; }
+}


### PR DESCRIPTION
## Summary
- agregar la entidad `TblPrueba` y su configuración en el contexto para mapear la tabla `tblPruebas`
- crear la migración inicial que genera la tabla con identidad, fecha por defecto y campo de teléfono de 10 caracteres

## Testing
- no se pudieron ejecutar pruebas (herramienta `dotnet` no disponible en el entorno)


------
https://chatgpt.com/codex/tasks/task_e_68dec1afad7083269b699547801809e3