### PR TITLE
Add consultation management API and UI

### DIFF
--- a/ProyectoCursoIA/Program.cs
+++ b/ProyectoCursoIA/Program.cs
@@ -1,6 +1,7 @@
+using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using ProyectoCursoIA.Data;
+using ProyectoCursoIA.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,14 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
@@ -18,6 +27,403 @@ using (var scope = app.Services.CreateScope())
     dbContext.Database.Migrate();
 }
 
-app.MapGet("/", () => "Hello World!");
+app.UseCors();
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+var api = app.MapGroup("/api");
+
+MapUsuarioEndpoints(api.MapGroup("/usuarios"));
+MapMedicoEndpoints(api.MapGroup("/medicos"));
+MapPacienteEndpoints(api.MapGroup("/pacientes"));
+MapConsultaEndpoints(api.MapGroup("/consultas"));
+MapLoginEndpoint(api);
 
 app.Run();
+
+static void MapUsuarioEndpoints(RouteGroupBuilder group)
+{
+    group.MapGet("/", async (ApplicationDbContext db) =>
+        await db.Usuarios
+            .AsNoTracking()
+            .ToListAsync());
+
+    group.MapGet("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var usuario = await db.Usuarios
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == id);
+
+        return usuario is not null ? Results.Ok(usuario) : Results.NotFound();
+    });
+
+    group.MapPost("/", async (Usuario usuario, ApplicationDbContext db) =>
+    {
+        db.Usuarios.Add(usuario);
+        await db.SaveChangesAsync();
+        return Results.Created($"/api/usuarios/{usuario.Id}", usuario);
+    });
+
+    group.MapPut("/{id:int}", async (int id, Usuario input, ApplicationDbContext db) =>
+    {
+        var usuario = await db.Usuarios.FindAsync(id);
+        if (usuario is null)
+        {
+            return Results.NotFound();
+        }
+
+        usuario.Correo = input.Correo;
+        usuario.Password = input.Password;
+        usuario.NombreCompleto = input.NombreCompleto;
+        usuario.IdMedico = input.IdMedico;
+        usuario.Activo = input.Activo;
+
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+
+    group.MapDelete("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var usuario = await db.Usuarios.FindAsync(id);
+        if (usuario is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Usuarios.Remove(usuario);
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+}
+
+static void MapMedicoEndpoints(RouteGroupBuilder group)
+{
+    group.MapGet("/", async (ApplicationDbContext db, bool? soloActivos) =>
+    {
+        var query = db.Medicos.AsNoTracking();
+
+        if (soloActivos is true)
+        {
+            query = query.Where(m => m.Activo);
+        }
+
+        var medicos = await query
+            .Select(m => new
+            {
+                id = m.Id,
+                primerNombre = m.PrimerNombre,
+                segundoNombre = m.SegundoNombre,
+                apellidoPaterno = m.ApellidoPaterno,
+                apellidoMaterno = m.ApellidoMaterno,
+                especialidad = m.Especialidad,
+                email = m.Email,
+                telefono = m.Telefono,
+                activo = m.Activo,
+                nombreCompleto = (m.PrimerNombre + " " + (m.SegundoNombre ?? "") + " " + m.ApellidoPaterno + " " + (m.ApellidoMaterno ?? "")).Trim()
+            })
+            .ToListAsync();
+
+        return Results.Ok(medicos);
+    });
+
+    group.MapGet("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var medico = await db.Medicos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == id);
+
+        return medico is not null ? Results.Ok(medico) : Results.NotFound();
+    });
+
+    group.MapPost("/", async (Medico medico, ApplicationDbContext db) =>
+    {
+        db.Medicos.Add(medico);
+        await db.SaveChangesAsync();
+        return Results.Created($"/api/medicos/{medico.Id}", medico);
+    });
+
+    group.MapPut("/{id:int}", async (int id, Medico input, ApplicationDbContext db) =>
+    {
+        var medico = await db.Medicos.FindAsync(id);
+        if (medico is null)
+        {
+            return Results.NotFound();
+        }
+
+        medico.PrimerNombre = input.PrimerNombre;
+        medico.SegundoNombre = input.SegundoNombre;
+        medico.ApellidoPaterno = input.ApellidoPaterno;
+        medico.ApellidoMaterno = input.ApellidoMaterno;
+        medico.Cedula = input.Cedula;
+        medico.Telefono = input.Telefono;
+        medico.Especialidad = input.Especialidad;
+        medico.Email = input.Email;
+        medico.Activo = input.Activo;
+
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+
+    group.MapDelete("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var medico = await db.Medicos.FindAsync(id);
+        if (medico is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Medicos.Remove(medico);
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+}
+
+static void MapPacienteEndpoints(RouteGroupBuilder group)
+{
+    group.MapGet("/", async (ApplicationDbContext db, bool? soloActivos) =>
+    {
+        var query = db.Pacientes.AsNoTracking();
+
+        if (soloActivos is true)
+        {
+            query = query.Where(p => p.Activo);
+        }
+
+        var pacientes = await query
+            .Select(p => new
+            {
+                id = p.Id,
+                primerNombre = p.PrimerNombre,
+                segundoNombre = p.SegundoNombre,
+                apellidoPaterno = p.ApellidoPaterno,
+                apellidoMaterno = p.ApellidoMaterno,
+                telefono = p.Telefono,
+                activo = p.Activo,
+                nombreCompleto = (p.PrimerNombre + " " + (p.SegundoNombre ?? "") + " " + p.ApellidoPaterno + " " + (p.ApellidoMaterno ?? "")).Trim()
+            })
+            .ToListAsync();
+
+        return Results.Ok(pacientes);
+    });
+
+    group.MapGet("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var paciente = await db.Pacientes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == id);
+
+        return paciente is not null ? Results.Ok(paciente) : Results.NotFound();
+    });
+
+    group.MapPost("/", async (Paciente paciente, ApplicationDbContext db) =>
+    {
+        db.Pacientes.Add(paciente);
+        await db.SaveChangesAsync();
+        return Results.Created($"/api/pacientes/{paciente.Id}", paciente);
+    });
+
+    group.MapPut("/{id:int}", async (int id, Paciente input, ApplicationDbContext db) =>
+    {
+        var paciente = await db.Pacientes.FindAsync(id);
+        if (paciente is null)
+        {
+            return Results.NotFound();
+        }
+
+        paciente.PrimerNombre = input.PrimerNombre;
+        paciente.SegundoNombre = input.SegundoNombre;
+        paciente.ApellidoPaterno = input.ApellidoPaterno;
+        paciente.ApellidoMaterno = input.ApellidoMaterno;
+        paciente.Telefono = input.Telefono;
+        paciente.Activo = input.Activo;
+
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+
+    group.MapDelete("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var paciente = await db.Pacientes.FindAsync(id);
+        if (paciente is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Pacientes.Remove(paciente);
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+}
+
+static void MapConsultaEndpoints(RouteGroupBuilder group)
+{
+    group.MapGet("/", async (ApplicationDbContext db, int? top) =>
+    {
+        var query = db.Consultas
+            .AsNoTracking()
+            .Include(c => c.Medico)
+            .Include(c => c.Paciente)
+            .OrderByDescending(c => c.Id);
+
+        if (top.HasValue)
+        {
+            query = query.Take(top.Value);
+        }
+
+        var consultas = await query
+            .Select(c => new ConsultaResponse(
+                c.Id,
+                c.IdMedico,
+                c.IdPaciente,
+                (c.Medico.PrimerNombre + " " + (c.Medico.SegundoNombre ?? "") + " " + c.Medico.ApellidoPaterno + " " + (c.Medico.ApellidoMaterno ?? "")).Trim(),
+                (c.Paciente.PrimerNombre + " " + (c.Paciente.SegundoNombre ?? "") + " " + c.Paciente.ApellidoPaterno + " " + (c.Paciente.ApellidoMaterno ?? "")).Trim(),
+                c.Sintomas,
+                c.Recomendaciones,
+                c.Diagnostico))
+            .ToListAsync();
+
+        return Results.Ok(consultas);
+    });
+
+    group.MapGet("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var consulta = await db.Consultas
+            .AsNoTracking()
+            .Include(c => c.Medico)
+            .Include(c => c.Paciente)
+            .Where(c => c.Id == id)
+            .Select(c => new ConsultaResponse(
+                c.Id,
+                c.IdMedico,
+                c.IdPaciente,
+                (c.Medico.PrimerNombre + " " + (c.Medico.SegundoNombre ?? "") + " " + c.Medico.ApellidoPaterno + " " + (c.Medico.ApellidoMaterno ?? "")).Trim(),
+                (c.Paciente.PrimerNombre + " " + (c.Paciente.SegundoNombre ?? "") + " " + c.Paciente.ApellidoPaterno + " " + (c.Paciente.ApellidoMaterno ?? "")).Trim(),
+                c.Sintomas,
+                c.Recomendaciones,
+                c.Diagnostico))
+            .FirstOrDefaultAsync();
+
+        return consulta is not null ? Results.Ok(consulta) : Results.NotFound();
+    });
+
+    group.MapPost("/", async (ConsultaRequest request, ApplicationDbContext db) =>
+    {
+        var medicoExiste = await db.Medicos.AnyAsync(m => m.Id == request.IdMedico);
+        if (!medicoExiste)
+        {
+            return Results.BadRequest(new { message = "El médico especificado no existe." });
+        }
+
+        var pacienteExiste = await db.Pacientes.AnyAsync(p => p.Id == request.IdPaciente);
+        if (!pacienteExiste)
+        {
+            return Results.BadRequest(new { message = "El paciente especificado no existe." });
+        }
+
+        var consulta = new Consulta
+        {
+            IdMedico = request.IdMedico,
+            IdPaciente = request.IdPaciente,
+            Sintomas = request.Sintomas,
+            Recomendaciones = request.Recomendaciones ?? string.Empty,
+            Diagnostico = request.Diagnostico ?? string.Empty
+        };
+
+        db.Consultas.Add(consulta);
+        await db.SaveChangesAsync();
+
+        var respuesta = await db.Consultas
+            .AsNoTracking()
+            .Include(c => c.Medico)
+            .Include(c => c.Paciente)
+            .Where(c => c.Id == consulta.Id)
+            .Select(c => new ConsultaResponse(
+                c.Id,
+                c.IdMedico,
+                c.IdPaciente,
+                (c.Medico.PrimerNombre + " " + (c.Medico.SegundoNombre ?? "") + " " + c.Medico.ApellidoPaterno + " " + (c.Medico.ApellidoMaterno ?? "")).Trim(),
+                (c.Paciente.PrimerNombre + " " + (c.Paciente.SegundoNombre ?? "") + " " + c.Paciente.ApellidoPaterno + " " + (c.Paciente.ApellidoMaterno ?? "")).Trim(),
+                c.Sintomas,
+                c.Recomendaciones,
+                c.Diagnostico))
+            .FirstAsync();
+
+        return Results.Created($"/api/consultas/{consulta.Id}", respuesta);
+    });
+
+    group.MapPut("/{id:int}", async (int id, ConsultaRequest request, ApplicationDbContext db) =>
+    {
+        var consulta = await db.Consultas.FindAsync(id);
+        if (consulta is null)
+        {
+            return Results.NotFound();
+        }
+
+        var medicoExiste = await db.Medicos.AnyAsync(m => m.Id == request.IdMedico);
+        if (!medicoExiste)
+        {
+            return Results.BadRequest(new { message = "El médico especificado no existe." });
+        }
+
+        var pacienteExiste = await db.Pacientes.AnyAsync(p => p.Id == request.IdPaciente);
+        if (!pacienteExiste)
+        {
+            return Results.BadRequest(new { message = "El paciente especificado no existe." });
+        }
+
+        consulta.IdMedico = request.IdMedico;
+        consulta.IdPaciente = request.IdPaciente;
+        consulta.Sintomas = request.Sintomas;
+        consulta.Recomendaciones = request.Recomendaciones ?? string.Empty;
+        consulta.Diagnostico = request.Diagnostico ?? string.Empty;
+
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+
+    group.MapDelete("/{id:int}", async (int id, ApplicationDbContext db) =>
+    {
+        var consulta = await db.Consultas.FindAsync(id);
+        if (consulta is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Consultas.Remove(consulta);
+        await db.SaveChangesAsync();
+        return Results.NoContent();
+    });
+}
+
+static void MapLoginEndpoint(RouteGroupBuilder group)
+{
+    group.MapPost("/login", async (LoginRequest request, ApplicationDbContext db) =>
+    {
+        var usuario = await db.Usuarios
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Correo == request.Correo && u.Password == request.Password);
+
+        if (usuario is null)
+        {
+            return Results.Unauthorized(new { message = "Usuario o contraseña incorrectos." });
+        }
+
+        if (!usuario.Activo)
+        {
+            return Results.Unauthorized(new { message = "El usuario no está activo." });
+        }
+
+        return Results.Ok(new
+        {
+            id = usuario.Id,
+            nombreCompleto = usuario.NombreCompleto,
+            correo = usuario.Correo
+        });
+    });
+}
+
+public record LoginRequest(string Correo, string Password);
+
+public record ConsultaRequest(int IdMedico, int IdPaciente, string Sintomas, string? Recomendaciones, string? Diagnostico);
+
+public record ConsultaResponse(int Id, int IdMedico, int IdPaciente, string MedicoNombre, string PacienteNombre, string Sintomas, string Recomendaciones, string Diagnostico);

--- a/ProyectoCursoIA/wwwroot/create-consulta.html
+++ b/ProyectoCursoIA/wwwroot/create-consulta.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prueba de CODEX - Crear consulta</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/create-consulta.js"></script>
+</head>
+<body class="app">
+    <header class="top-bar">
+        <h1>Prueba de CODEX</h1>
+        <nav>
+            <a href="dashboard.html" class="button button--ghost">Volver al dashboard</a>
+            <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        </nav>
+    </header>
+    <main class="content">
+        <section class="card">
+            <h2>Registrar nueva consulta</h2>
+            <p class="text-subtle">Completa la información para vincular a un paciente con un médico.</p>
+            <form id="consultaForm">
+                <label for="medicoSelect">
+                    Médico
+                    <select id="medicoSelect" name="medico" required>
+                        <option value="">Cargando médicos...</option>
+                    </select>
+                </label>
+                <label for="pacienteSelect">
+                    Paciente
+                    <select id="pacienteSelect" name="paciente" required>
+                        <option value="">Cargando pacientes...</option>
+                    </select>
+                </label>
+                <label for="sintomas">
+                    Síntomas
+                    <textarea id="sintomas" name="sintomas" placeholder="Describe los síntomas del paciente" required></textarea>
+                </label>
+                <label for="recomendaciones">
+                    Recomendaciones
+                    <textarea id="recomendaciones" name="recomendaciones" placeholder="Escribe recomendaciones (opcional)"></textarea>
+                </label>
+                <label for="diagnostico">
+                    Diagnóstico
+                    <textarea id="diagnostico" name="diagnostico" placeholder="Escribe el diagnóstico (opcional)"></textarea>
+                </label>
+                <div id="consultaFeedback" role="alert"></div>
+                <button type="submit">Guardar consulta</button>
+            </form>
+        </section>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/ProyectoCursoIA/wwwroot/css/styles.css
+++ b/ProyectoCursoIA/wwwroot/css/styles.css
@@ -1,0 +1,251 @@
+:root {
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-tertiary: #111827;
+    --text-primary: #f8fafc;
+    --text-secondary: #cbd5f5;
+    --accent: #38bdf8;
+    --accent-hover: #0ea5e9;
+    --danger: #f87171;
+    --success: #34d399;
+    --border-color: rgba(148, 163, 184, 0.25);
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 55%), var(--bg-primary);
+    color: var(--text-primary);
+    font-family: inherit;
+    display: flex;
+    flex-direction: column;
+}
+
+.app {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.app--centered {
+    justify-content: center;
+    align-items: center;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem clamp(1rem, 4vw, 3rem);
+    background: rgba(15, 23, 42, 0.9);
+    border-bottom: 1px solid var(--border-color);
+    backdrop-filter: blur(16px);
+}
+
+.top-bar h1 {
+    margin: 0;
+    font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+    font-weight: 700;
+}
+
+.top-bar nav {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.content {
+    flex: 1;
+    width: min(1100px, 92vw);
+    margin: clamp(1rem, 3vw, 2rem) auto 3rem;
+    display: grid;
+    gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.card {
+    background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
+    border-radius: 1.25rem;
+    padding: clamp(1.25rem, 3vw, 2rem);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+}
+
+.card--narrow {
+    width: min(420px, 90vw);
+}
+
+.card h1,
+.card h2,
+.card h3 {
+    margin-top: 0;
+    font-weight: 600;
+}
+
+.card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.button,
+button,
+input[type="submit"],
+input[type="button"] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--accent);
+    color: var(--bg-primary);
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+    text-decoration: none;
+}
+
+.button:hover,
+button:hover,
+input[type="submit"]:hover,
+input[type="button"]:hover {
+    background: var(--accent-hover);
+    transform: translateY(-1px);
+}
+
+.button--ghost {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+}
+
+.button--ghost:hover {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-primary);
+}
+
+form {
+    display: grid;
+    gap: 1.25rem;
+}
+
+label {
+    display: grid;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+input[type="email"],
+input[type="password"],
+input[type="text"],
+select,
+textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 0.85rem;
+    border: 1px solid transparent;
+    background: rgba(15, 23, 42, 0.75);
+    color: var(--text-primary);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea {
+    min-height: 110px;
+    resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.alert {
+    border-radius: 0.75rem;
+    padding: 0.85rem 1rem;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.alert--error {
+    border-color: rgba(248, 113, 113, 0.45);
+    color: var(--danger);
+}
+
+.alert--success {
+    border-color: rgba(52, 211, 153, 0.45);
+    color: var(--success);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.75rem;
+}
+
+.table thead {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.table th,
+.table td {
+    padding: 0.9rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.table tbody tr:hover {
+    background: rgba(56, 189, 248, 0.08);
+}
+
+.empty-state {
+    padding: 1rem 0;
+    color: var(--text-secondary);
+}
+
+.loading {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.text-subtle {
+    color: var(--text-secondary);
+    margin-top: 0.35rem;
+}
+
+.footer {
+    text-align: center;
+    padding: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+    .card__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .table th,
+    .table td {
+        padding: 0.75rem 0.5rem;
+    }
+}

--- a/ProyectoCursoIA/wwwroot/dashboard.html
+++ b/ProyectoCursoIA/wwwroot/dashboard.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prueba de CODEX - Dashboard</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/dashboard.js"></script>
+</head>
+<body class="app">
+    <header class="top-bar">
+        <h1>Prueba de CODEX</h1>
+        <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+    </header>
+    <main class="content">
+        <section class="card">
+            <h2 id="greeting">Hola</h2>
+            <p class="text-subtle">Gracias por iniciar sesión. Aquí encontrarás un resumen de las consultas más recientes.</p>
+        </section>
+        <section class="card">
+            <div class="card__header">
+                <h2>Últimas consultas</h2>
+                <a class="button" href="create-consulta.html">Crear consulta</a>
+            </div>
+            <div id="consultasContainer"></div>
+        </section>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/ProyectoCursoIA/wwwroot/index.html
+++ b/ProyectoCursoIA/wwwroot/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prueba de CODEX - Login</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/login.js"></script>
+</head>
+<body class="app app--centered">
+    <main class="card card--narrow">
+        <header>
+            <h1>Prueba de CODEX</h1>
+            <p class="text-subtle">Inicia sesión para acceder al panel de consultas.</p>
+        </header>
+        <form id="loginForm" autocomplete="off">
+            <label for="correo">
+                Correo electrónico
+                <input type="email" id="correo" name="correo" placeholder="correo@ejemplo.com" required />
+            </label>
+            <label for="password">
+                Contraseña
+                <input type="password" id="password" name="password" placeholder="Ingresa tu contraseña" required />
+            </label>
+            <div id="loginFeedback" role="alert"></div>
+            <button type="submit">Iniciar sesión</button>
+        </form>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX. Todos los derechos reservados.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/ProyectoCursoIA/wwwroot/js/common.js
+++ b/ProyectoCursoIA/wwwroot/js/common.js
@@ -1,0 +1,66 @@
+const API_BASE = "/api";
+
+function saveUser(user) {
+    sessionStorage.setItem("usuario", JSON.stringify(user));
+}
+
+function getStoredUser() {
+    const raw = sessionStorage.getItem("usuario");
+    if (!raw) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(raw);
+    } catch (error) {
+        console.error("No se pudo leer la información del usuario", error);
+        sessionStorage.removeItem("usuario");
+        return null;
+    }
+}
+
+function requireUser() {
+    const user = getStoredUser();
+    if (!user) {
+        window.location.href = "index.html";
+        return null;
+    }
+
+    return user;
+}
+
+function logout() {
+    sessionStorage.removeItem("usuario");
+    window.location.href = "index.html";
+}
+
+async function fetchJson(url, options = {}) {
+    const response = await fetch(url, {
+        headers: {
+            "Content-Type": "application/json",
+            ...(options.headers || {})
+        },
+        ...options
+    });
+
+    let data = null;
+    try {
+        data = await response.json();
+    } catch (error) {
+        // Ignoramos si no hay cuerpo JSON
+    }
+
+    if (!response.ok) {
+        const message = data?.message || "Ocurrió un error inesperado.";
+        throw new Error(message);
+    }
+
+    return data;
+}
+
+function buildNombreCompleto({ primerNombre = "", segundoNombre = "", apellidoPaterno = "", apellidoMaterno = "" }) {
+    return [primerNombre, segundoNombre, apellidoPaterno, apellidoMaterno]
+        .map((parte) => parte?.trim())
+        .filter((parte) => parte)
+        .join(" ");
+}

--- a/ProyectoCursoIA/wwwroot/js/create-consulta.js
+++ b/ProyectoCursoIA/wwwroot/js/create-consulta.js
@@ -1,0 +1,81 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const user = requireUser();
+    if (!user) {
+        return;
+    }
+
+    const form = document.getElementById("consultaForm");
+    const feedback = document.getElementById("consultaFeedback");
+    const medicoSelect = document.getElementById("medicoSelect");
+    const pacienteSelect = document.getElementById("pacienteSelect");
+    const logoutButton = document.getElementById("logoutButton");
+
+    logoutButton?.addEventListener("click", () => logout());
+
+    async function cargarOpciones() {
+        try {
+            const [medicos, pacientes] = await Promise.all([
+                fetchJson(`${API_BASE}/medicos?soloActivos=true`),
+                fetchJson(`${API_BASE}/pacientes?soloActivos=true`)
+            ]);
+
+            medicoSelect.innerHTML = medicos
+                .map((medico) => `<option value="${medico.id}">${medico.nombreCompleto}</option>`)
+                .join("");
+
+            pacienteSelect.innerHTML = pacientes
+                .map((paciente) => `<option value="${paciente.id}">${paciente.nombreCompleto}</option>`)
+                .join("");
+
+            if (!medicos.length || !pacientes.length) {
+                feedback.textContent = "Es necesario contar con médicos y pacientes activos para registrar una consulta.";
+                feedback.className = "alert alert--error";
+            }
+        } catch (error) {
+            feedback.textContent = error.message;
+            feedback.className = "alert alert--error";
+        }
+    }
+
+    await cargarOpciones();
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        feedback.textContent = "";
+        feedback.className = "";
+
+        if (!medicoSelect.value || !pacienteSelect.value) {
+            feedback.textContent = "Selecciona un médico y un paciente.";
+            feedback.className = "alert alert--error";
+            return;
+        }
+
+        const payload = {
+            idMedico: Number(medicoSelect.value),
+            idPaciente: Number(pacienteSelect.value),
+            sintomas: form.sintomas.value.trim(),
+            recomendaciones: form.recomendaciones.value.trim(),
+            diagnostico: form.diagnostico.value.trim()
+        };
+
+        if (!payload.sintomas) {
+            feedback.textContent = "Captura los síntomas de la consulta.";
+            feedback.className = "alert alert--error";
+            return;
+        }
+
+        try {
+            await fetchJson(`${API_BASE}/consultas`, {
+                method: "POST",
+                body: JSON.stringify(payload)
+            });
+
+            feedback.textContent = "La consulta se registró correctamente.";
+            feedback.className = "alert alert--success";
+            form.reset();
+        } catch (error) {
+            feedback.textContent = error.message;
+            feedback.className = "alert alert--error";
+        }
+    });
+});

--- a/ProyectoCursoIA/wwwroot/js/dashboard.js
+++ b/ProyectoCursoIA/wwwroot/js/dashboard.js
@@ -1,0 +1,57 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const user = requireUser();
+    if (!user) {
+        return;
+    }
+
+    const greeting = document.getElementById("greeting");
+    const consultasContainer = document.getElementById("consultasContainer");
+    const logoutButton = document.getElementById("logoutButton");
+
+    greeting.textContent = `Hola, ${user.nombreCompleto}`;
+
+    logoutButton?.addEventListener("click", () => {
+        logout();
+    });
+
+    consultasContainer.innerHTML = "<p class=\"loading\">Cargando consultas recientes...</p>";
+
+    try {
+        const consultas = await fetchJson(`${API_BASE}/consultas?top=10`);
+
+        if (!consultas.length) {
+            consultasContainer.innerHTML = "<p class=\"empty-state\">Aún no se han registrado consultas.</p>";
+            return;
+        }
+
+        const table = document.createElement("table");
+        table.className = "table";
+        table.innerHTML = `
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Médico</th>
+                    <th>Paciente</th>
+                    <th>Síntomas</th>
+                    <th>Diagnóstico</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${consultas.map((consulta) => `
+                    <tr>
+                        <td>#${consulta.id}</td>
+                        <td>${consulta.medicoNombre}</td>
+                        <td>${consulta.pacienteNombre}</td>
+                        <td>${consulta.sintomas}</td>
+                        <td>${consulta.diagnostico || "-"}</td>
+                    </tr>
+                `).join("")}
+            </tbody>
+        `;
+
+        consultasContainer.innerHTML = "";
+        consultasContainer.appendChild(table);
+    } catch (error) {
+        consultasContainer.innerHTML = `<p class="alert alert--error">${error.message}</p>`;
+    }
+});

--- a/ProyectoCursoIA/wwwroot/js/login.js
+++ b/ProyectoCursoIA/wwwroot/js/login.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("loginForm");
+    const feedback = document.getElementById("loginFeedback");
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        feedback.textContent = "";
+        feedback.className = "";
+
+        const correo = form.correo.value.trim();
+        const password = form.password.value.trim();
+
+        if (!correo || !password) {
+            feedback.textContent = "Ingresa tu correo y contraseña.";
+            feedback.className = "alert alert--error";
+            return;
+        }
+
+        try {
+            const data = await fetchJson(`${API_BASE}/login`, {
+                method: "POST",
+                body: JSON.stringify({ correo, password })
+            });
+
+            saveUser(data);
+            window.location.href = "dashboard.html";
+        } catch (error) {
+            feedback.textContent = error.message;
+            feedback.className = "alert alert--error";
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add grouped minimal API endpoints for usuarios, médicos, pacientes, consultas, and login authentication
- enable static hosting and create responsive dark-themed login, dashboard, and create-consulta pages that consume the new APIs
- share front-end helpers for authentication, API calls, and form interactions

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df045338f08326b09535002dcdf724