### PR TITLE
Fix consulta query ordering assignment

### DIFF
--- a/ProyectoCursoIA/Program.cs
+++ b/ProyectoCursoIA/Program.cs
@@ -263,7 +263,9 @@ static void MapConsultaEndpoints(RouteGroupBuilder group)
             .AsNoTracking()
             .Include(c => c.Medico)
             .Include(c => c.Paciente)
-            .OrderByDescending(c => c.Id);
+            .AsQueryable();
+
+        query = query.OrderByDescending(c => c.Id);
 
         if (top.HasValue)
         {


### PR DESCRIPTION
## Summary
- adjust consulta list query to keep it assignable when limiting results

## Testing
- not run (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df07d3c65083269616b4b8391e0e5f