### PR TITLE
Fix nullable entity properties to match schema

### DIFF
--- a/ProyectoCursoIA/Models/Consulta.cs
+++ b/ProyectoCursoIA/Models/Consulta.cs
@@ -8,8 +8,8 @@ public class Consulta
     public int IdMedico { get; set; }
     public int IdPaciente { get; set; }
     public string Sintomas { get; set; } = string.Empty;
-    public string Recomendaciones { get; set; } = string.Empty;
-    public string Diagnostico { get; set; } = string.Empty;
+    public string? Recomendaciones { get; set; }
+    public string? Diagnostico { get; set; }
 
     public Medico Medico { get; set; } = null!;
     public Paciente Paciente { get; set; } = null!;

--- a/ProyectoCursoIA/Models/Medico.cs
+++ b/ProyectoCursoIA/Models/Medico.cs
@@ -7,9 +7,9 @@ public class Medico
 {
     public int Id { get; set; }
     public string PrimerNombre { get; set; } = string.Empty;
-    public string SegundoNombre { get; set; } = string.Empty;
+    public string? SegundoNombre { get; set; }
     public string ApellidoPaterno { get; set; } = string.Empty;
-    public string ApellidoMaterno { get; set; } = string.Empty;
+    public string? ApellidoMaterno { get; set; }
     public string Cedula { get; set; } = string.Empty;
     public long Telefono { get; set; }
     public string Especialidad { get; set; } = string.Empty;

--- a/ProyectoCursoIA/Models/Paciente.cs
+++ b/ProyectoCursoIA/Models/Paciente.cs
@@ -7,9 +7,9 @@ public class Paciente
 {
     public int Id { get; set; }
     public string PrimerNombre { get; set; } = string.Empty;
-    public string SegundoNombre { get; set; } = string.Empty;
+    public string? SegundoNombre { get; set; }
     public string ApellidoPaterno { get; set; } = string.Empty;
-    public string ApellidoMaterno { get; set; } = string.Empty;
+    public string? ApellidoMaterno { get; set; }
     public string Telefono { get; set; } = string.Empty;
     public bool Activo { get; set; } = true;
     public DateTime FechaCreacion { get; set; }

--- a/ProyectoCursoIA/Program.cs
+++ b/ProyectoCursoIA/Program.cs
@@ -328,8 +328,8 @@ static void MapConsultaEndpoints(RouteGroupBuilder group)
             IdMedico = request.IdMedico,
             IdPaciente = request.IdPaciente,
             Sintomas = request.Sintomas,
-            Recomendaciones = request.Recomendaciones ?? string.Empty,
-            Diagnostico = request.Diagnostico ?? string.Empty
+            Recomendaciones = request.Recomendaciones,
+            Diagnostico = request.Diagnostico
         };
 
         db.Consultas.Add(consulta);
@@ -377,8 +377,8 @@ static void MapConsultaEndpoints(RouteGroupBuilder group)
         consulta.IdMedico = request.IdMedico;
         consulta.IdPaciente = request.IdPaciente;
         consulta.Sintomas = request.Sintomas;
-        consulta.Recomendaciones = request.Recomendaciones ?? string.Empty;
-        consulta.Diagnostico = request.Diagnostico ?? string.Empty;
+        consulta.Recomendaciones = request.Recomendaciones;
+        consulta.Diagnostico = request.Diagnostico;
 
         await db.SaveChangesAsync();
         return Results.NoContent();
@@ -433,4 +433,4 @@ public record LoginRequest(string Correo, string Password);
 
 public record ConsultaRequest(int IdMedico, int IdPaciente, string Sintomas, string? Recomendaciones, string? Diagnostico);
 
-public record ConsultaResponse(int Id, int IdMedico, int IdPaciente, string MedicoNombre, string PacienteNombre, string Sintomas, string Recomendaciones, string Diagnostico);
+public record ConsultaResponse(int Id, int IdMedico, int IdPaciente, string MedicoNombre, string PacienteNombre, string Sintomas, string? Recomendaciones, string? Diagnostico);


### PR DESCRIPTION
## Summary
- mark optional columns in Consulta, Medico, and Paciente entities as nullable reference types to match the current database schema
- update Consulta endpoint handling and response contract to propagate nullable recommendation and diagnostic values consistently

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0990be1c8326b752d0a781d20642