### PR TITLE
Add CRUD interfaces for usuarios, médicos y pacientes

### DIFF
--- a/ProyectoCursoIA/wwwroot/css/styles.css
+++ b/ProyectoCursoIA/wwwroot/css/styles.css
@@ -145,6 +145,18 @@ label {
     font-size: 0.95rem;
 }
 
+.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.checkbox input[type="checkbox"] {
+    width: auto;
+    accent-color: var(--accent);
+    transform: scale(1.1);
+}
+
 input[type="email"],
 input[type="password"],
 input[type="text"],
@@ -192,6 +204,12 @@ textarea:focus {
     color: var(--success);
 }
 
+.form__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
 .table {
     width: 100%;
     border-collapse: collapse;
@@ -214,6 +232,29 @@ textarea:focus {
 
 .table tbody tr:hover {
     background: rgba(56, 189, 248, 0.08);
+}
+
+.table-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.button--sm,
+button.button--sm {
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+}
+
+.button--danger,
+button.button--danger {
+    background: var(--danger);
+    color: var(--bg-primary);
+}
+
+.button--danger:hover,
+button.button--danger:hover {
+    background: #ef4444;
 }
 
 .empty-state {

--- a/ProyectoCursoIA/wwwroot/dashboard.html
+++ b/ProyectoCursoIA/wwwroot/dashboard.html
@@ -11,7 +11,13 @@
 <body class="app">
     <header class="top-bar">
         <h1>Prueba de CODEX</h1>
-        <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        <nav>
+            <a class="button button--ghost" href="dashboard.html">Dashboard</a>
+            <a class="button button--ghost" href="usuarios.html">Usuarios</a>
+            <a class="button button--ghost" href="medicos.html">Médicos</a>
+            <a class="button button--ghost" href="pacientes.html">Pacientes</a>
+            <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        </nav>
     </header>
     <main class="content">
         <section class="card">

--- a/ProyectoCursoIA/wwwroot/js/medicos.js
+++ b/ProyectoCursoIA/wwwroot/js/medicos.js
@@ -1,0 +1,255 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const user = requireUser();
+    if (!user) {
+        return;
+    }
+
+    const logoutButton = document.getElementById("logoutButton");
+    logoutButton?.addEventListener("click", () => logout());
+
+    const form = document.getElementById("medicoForm");
+    const formTitle = document.getElementById("medicoFormTitle");
+    const formFeedback = document.getElementById("medicoFormFeedback");
+
+    const primerNombreInput = document.getElementById("medicoPrimerNombre");
+    const segundoNombreInput = document.getElementById("medicoSegundoNombre");
+    const apellidoPaternoInput = document.getElementById("medicoApellidoPaterno");
+    const apellidoMaternoInput = document.getElementById("medicoApellidoMaterno");
+    const cedulaInput = document.getElementById("medicoCedula");
+    const telefonoInput = document.getElementById("medicoTelefono");
+    const especialidadInput = document.getElementById("medicoEspecialidad");
+    const emailInput = document.getElementById("medicoEmail");
+    const activoCheckbox = document.getElementById("medicoActivo");
+
+    const submitButton = document.getElementById("medicoSubmitButton");
+    const cancelButton = document.getElementById("medicoCancelButton");
+    const listFeedback = document.getElementById("medicosListFeedback");
+    const reloadButton = document.getElementById("medicosReloadButton");
+    const tableBody = document.getElementById("medicosTableBody");
+
+    let medicos = [];
+    let editingId = null;
+
+    function showFeedback(element, message = "", tone) {
+        if (!element) {
+            return;
+        }
+
+        element.textContent = message;
+
+        if (!message) {
+            element.className = "";
+            return;
+        }
+
+        switch (tone) {
+            case "error":
+                element.className = "alert alert--error";
+                break;
+            case "success":
+                element.className = "alert alert--success";
+                break;
+            case "loading":
+                element.className = "loading";
+                break;
+            case "muted":
+                element.className = "text-subtle";
+                break;
+            default:
+                element.className = "alert";
+                break;
+        }
+    }
+
+    function renderMedicos() {
+        if (!medicos.length) {
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="7" class="empty-state">No hay médicos registrados.</td>
+                </tr>
+            `;
+            return;
+        }
+
+        tableBody.innerHTML = medicos
+            .map((medico) => {
+                const nombre = medico.nombreCompleto || buildNombreCompleto(medico);
+                const estado = medico.activo ? "Activo" : "Inactivo";
+                return `
+                    <tr>
+                        <td>#${medico.id}</td>
+                        <td>${nombre}</td>
+                        <td>${medico.especialidad}</td>
+                        <td>${medico.email}</td>
+                        <td>${medico.telefono}</td>
+                        <td>${estado}</td>
+                        <td>
+                            <div class="table-actions">
+                                <button type="button" class="button button--sm" data-action="edit" data-id="${medico.id}">Editar</button>
+                                <button type="button" class="button button--sm button--danger" data-action="delete" data-id="${medico.id}">Eliminar</button>
+                            </div>
+                        </td>
+                    </tr>
+                `;
+            })
+            .join("");
+    }
+
+    function resetForm(options = {}) {
+        editingId = null;
+        form.reset();
+        activoCheckbox.checked = true;
+        formTitle.textContent = "Registrar médico";
+        submitButton.textContent = "Registrar médico";
+        cancelButton.hidden = true;
+
+        if (!options.keepFeedback) {
+            showFeedback(formFeedback);
+        }
+    }
+
+    async function loadMedicos() {
+        showFeedback(listFeedback, "Cargando médicos...", "loading");
+
+        try {
+            medicos = await fetchJson(`${API_BASE}/medicos`);
+            renderMedicos();
+            showFeedback(listFeedback);
+        } catch (error) {
+            medicos = [];
+            tableBody.innerHTML = "";
+            showFeedback(listFeedback, error.message, "error");
+        }
+    }
+
+    function startEditing(medico) {
+        editingId = medico.id;
+        formTitle.textContent = `Editar médico #${medico.id}`;
+        submitButton.textContent = "Guardar cambios";
+        cancelButton.hidden = false;
+
+        primerNombreInput.value = medico.primerNombre;
+        segundoNombreInput.value = medico.segundoNombre ?? "";
+        apellidoPaternoInput.value = medico.apellidoPaterno;
+        apellidoMaternoInput.value = medico.apellidoMaterno ?? "";
+        cedulaInput.value = medico.cedula;
+        telefonoInput.value = medico.telefono?.toString() ?? "";
+        especialidadInput.value = medico.especialidad;
+        emailInput.value = medico.email;
+        activoCheckbox.checked = medico.activo;
+
+        showFeedback(formFeedback, "Modificando médico seleccionado.", "muted");
+        form.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    tableBody.addEventListener("click", async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+
+        const action = target.dataset.action;
+        const id = Number(target.dataset.id);
+
+        if (!action || Number.isNaN(id)) {
+            return;
+        }
+
+        const medico = medicos.find((item) => item.id === id);
+        if (!medico) {
+            return;
+        }
+
+        if (action === "edit") {
+            startEditing(medico);
+            return;
+        }
+
+        if (action === "delete") {
+            const confirmed = window.confirm("¿Deseas eliminar este médico?");
+            if (!confirmed) {
+                return;
+            }
+
+            try {
+                await fetchJson(`${API_BASE}/medicos/${id}`, { method: "DELETE" });
+                await loadMedicos();
+                if (editingId === id) {
+                    resetForm();
+                }
+                showFeedback(listFeedback, "El médico se eliminó correctamente.", "success");
+            } catch (error) {
+                showFeedback(listFeedback, error.message, "error");
+            }
+        }
+    });
+
+    cancelButton.addEventListener("click", () => {
+        resetForm();
+    });
+
+    reloadButton.addEventListener("click", () => {
+        loadMedicos();
+    });
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        showFeedback(formFeedback);
+
+        const primerNombre = primerNombreInput.value.trim();
+        const segundoNombre = segundoNombreInput.value.trim();
+        const apellidoPaterno = apellidoPaternoInput.value.trim();
+        const apellidoMaterno = apellidoMaternoInput.value.trim();
+        const cedula = cedulaInput.value.trim();
+        const telefonoRaw = telefonoInput.value.trim();
+        const especialidad = especialidadInput.value.trim();
+        const email = emailInput.value.trim();
+
+        if (!primerNombre || !apellidoPaterno || !cedula || !especialidad || !email || !telefonoRaw) {
+            showFeedback(formFeedback, "Completa todos los campos obligatorios.", "error");
+            return;
+        }
+
+        const telefonoDigits = telefonoRaw.replace(/\D+/g, "");
+        if (!telefonoDigits) {
+            showFeedback(formFeedback, "Captura un número de teléfono válido.", "error");
+            return;
+        }
+
+        const payload = {
+            primerNombre,
+            segundoNombre: segundoNombre || null,
+            apellidoPaterno,
+            apellidoMaterno: apellidoMaterno || null,
+            cedula,
+            telefono: Number(telefonoDigits),
+            especialidad,
+            email,
+            activo: activoCheckbox.checked
+        };
+
+        const wasEditing = Boolean(editingId);
+        const url = wasEditing ? `${API_BASE}/medicos/${editingId}` : `${API_BASE}/medicos`;
+        const method = wasEditing ? "PUT" : "POST";
+
+        try {
+            await fetchJson(url, {
+                method,
+                body: JSON.stringify(payload)
+            });
+
+            await loadMedicos();
+            resetForm({ keepFeedback: true });
+
+            const message = wasEditing
+                ? "El médico se actualizó correctamente."
+                : "El médico se registró correctamente.";
+
+            showFeedback(formFeedback, message, "success");
+        } catch (error) {
+            showFeedback(formFeedback, error.message, "error");
+        }
+    });
+
+    await loadMedicos();
+});

--- a/ProyectoCursoIA/wwwroot/js/pacientes.js
+++ b/ProyectoCursoIA/wwwroot/js/pacientes.js
@@ -1,0 +1,235 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const user = requireUser();
+    if (!user) {
+        return;
+    }
+
+    const logoutButton = document.getElementById("logoutButton");
+    logoutButton?.addEventListener("click", () => logout());
+
+    const form = document.getElementById("pacienteForm");
+    const formTitle = document.getElementById("pacienteFormTitle");
+    const formFeedback = document.getElementById("pacienteFormFeedback");
+
+    const primerNombreInput = document.getElementById("pacientePrimerNombre");
+    const segundoNombreInput = document.getElementById("pacienteSegundoNombre");
+    const apellidoPaternoInput = document.getElementById("pacienteApellidoPaterno");
+    const apellidoMaternoInput = document.getElementById("pacienteApellidoMaterno");
+    const telefonoInput = document.getElementById("pacienteTelefono");
+    const activoCheckbox = document.getElementById("pacienteActivo");
+
+    const submitButton = document.getElementById("pacienteSubmitButton");
+    const cancelButton = document.getElementById("pacienteCancelButton");
+    const listFeedback = document.getElementById("pacientesListFeedback");
+    const reloadButton = document.getElementById("pacientesReloadButton");
+    const tableBody = document.getElementById("pacientesTableBody");
+
+    let pacientes = [];
+    let editingId = null;
+
+    function showFeedback(element, message = "", tone) {
+        if (!element) {
+            return;
+        }
+
+        element.textContent = message;
+
+        if (!message) {
+            element.className = "";
+            return;
+        }
+
+        switch (tone) {
+            case "error":
+                element.className = "alert alert--error";
+                break;
+            case "success":
+                element.className = "alert alert--success";
+                break;
+            case "loading":
+                element.className = "loading";
+                break;
+            case "muted":
+                element.className = "text-subtle";
+                break;
+            default:
+                element.className = "alert";
+                break;
+        }
+    }
+
+    function renderPacientes() {
+        if (!pacientes.length) {
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="5" class="empty-state">No hay pacientes registrados.</td>
+                </tr>
+            `;
+            return;
+        }
+
+        tableBody.innerHTML = pacientes
+            .map((paciente) => {
+                const nombre = paciente.nombreCompleto || buildNombreCompleto(paciente);
+                const estado = paciente.activo ? "Activo" : "Inactivo";
+                return `
+                    <tr>
+                        <td>#${paciente.id}</td>
+                        <td>${nombre}</td>
+                        <td>${paciente.telefono}</td>
+                        <td>${estado}</td>
+                        <td>
+                            <div class="table-actions">
+                                <button type="button" class="button button--sm" data-action="edit" data-id="${paciente.id}">Editar</button>
+                                <button type="button" class="button button--sm button--danger" data-action="delete" data-id="${paciente.id}">Eliminar</button>
+                            </div>
+                        </td>
+                    </tr>
+                `;
+            })
+            .join("");
+    }
+
+    function resetForm(options = {}) {
+        editingId = null;
+        form.reset();
+        activoCheckbox.checked = true;
+        formTitle.textContent = "Registrar paciente";
+        submitButton.textContent = "Registrar paciente";
+        cancelButton.hidden = true;
+
+        if (!options.keepFeedback) {
+            showFeedback(formFeedback);
+        }
+    }
+
+    async function loadPacientes() {
+        showFeedback(listFeedback, "Cargando pacientes...", "loading");
+
+        try {
+            pacientes = await fetchJson(`${API_BASE}/pacientes`);
+            renderPacientes();
+            showFeedback(listFeedback);
+        } catch (error) {
+            pacientes = [];
+            tableBody.innerHTML = "";
+            showFeedback(listFeedback, error.message, "error");
+        }
+    }
+
+    function startEditing(paciente) {
+        editingId = paciente.id;
+        formTitle.textContent = `Editar paciente #${paciente.id}`;
+        submitButton.textContent = "Guardar cambios";
+        cancelButton.hidden = false;
+
+        primerNombreInput.value = paciente.primerNombre;
+        segundoNombreInput.value = paciente.segundoNombre ?? "";
+        apellidoPaternoInput.value = paciente.apellidoPaterno;
+        apellidoMaternoInput.value = paciente.apellidoMaterno ?? "";
+        telefonoInput.value = paciente.telefono ?? "";
+        activoCheckbox.checked = paciente.activo;
+
+        showFeedback(formFeedback, "Modificando paciente seleccionado.", "muted");
+        form.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    tableBody.addEventListener("click", async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+
+        const action = target.dataset.action;
+        const id = Number(target.dataset.id);
+
+        if (!action || Number.isNaN(id)) {
+            return;
+        }
+
+        const paciente = pacientes.find((item) => item.id === id);
+        if (!paciente) {
+            return;
+        }
+
+        if (action === "edit") {
+            startEditing(paciente);
+            return;
+        }
+
+        if (action === "delete") {
+            const confirmed = window.confirm("¿Deseas eliminar este paciente?");
+            if (!confirmed) {
+                return;
+            }
+
+            try {
+                await fetchJson(`${API_BASE}/pacientes/${id}`, { method: "DELETE" });
+                await loadPacientes();
+                if (editingId === id) {
+                    resetForm();
+                }
+                showFeedback(listFeedback, "El paciente se eliminó correctamente.", "success");
+            } catch (error) {
+                showFeedback(listFeedback, error.message, "error");
+            }
+        }
+    });
+
+    cancelButton.addEventListener("click", () => {
+        resetForm();
+    });
+
+    reloadButton.addEventListener("click", () => {
+        loadPacientes();
+    });
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        showFeedback(formFeedback);
+
+        const primerNombre = primerNombreInput.value.trim();
+        const segundoNombre = segundoNombreInput.value.trim();
+        const apellidoPaterno = apellidoPaternoInput.value.trim();
+        const apellidoMaterno = apellidoMaternoInput.value.trim();
+        const telefono = telefonoInput.value.trim();
+
+        if (!primerNombre || !apellidoPaterno || !telefono) {
+            showFeedback(formFeedback, "Completa todos los campos obligatorios.", "error");
+            return;
+        }
+
+        const payload = {
+            primerNombre,
+            segundoNombre: segundoNombre || null,
+            apellidoPaterno,
+            apellidoMaterno: apellidoMaterno || null,
+            telefono,
+            activo: activoCheckbox.checked
+        };
+
+        const wasEditing = Boolean(editingId);
+        const url = wasEditing ? `${API_BASE}/pacientes/${editingId}` : `${API_BASE}/pacientes`;
+        const method = wasEditing ? "PUT" : "POST";
+
+        try {
+            await fetchJson(url, {
+                method,
+                body: JSON.stringify(payload)
+            });
+
+            await loadPacientes();
+            resetForm({ keepFeedback: true });
+
+            const message = wasEditing
+                ? "El paciente se actualizó correctamente."
+                : "El paciente se registró correctamente.";
+
+            showFeedback(formFeedback, message, "success");
+        } catch (error) {
+            showFeedback(formFeedback, error.message, "error");
+        }
+    });
+
+    await loadPacientes();
+});

--- a/ProyectoCursoIA/wwwroot/js/usuarios.js
+++ b/ProyectoCursoIA/wwwroot/js/usuarios.js
@@ -1,0 +1,272 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const user = requireUser();
+    if (!user) {
+        return;
+    }
+
+    const logoutButton = document.getElementById("logoutButton");
+    logoutButton?.addEventListener("click", () => logout());
+
+    const form = document.getElementById("usuarioForm");
+    const formTitle = document.getElementById("usuarioFormTitle");
+    const formFeedback = document.getElementById("usuarioFormFeedback");
+    const correoInput = document.getElementById("usuarioCorreo");
+    const passwordInput = document.getElementById("usuarioPassword");
+    const nombreInput = document.getElementById("usuarioNombreCompleto");
+    const medicoSelect = document.getElementById("usuarioMedico");
+    const activoCheckbox = document.getElementById("usuarioActivo");
+    const submitButton = document.getElementById("usuarioSubmitButton");
+    const cancelButton = document.getElementById("usuarioCancelButton");
+
+    const listFeedback = document.getElementById("usuariosListFeedback");
+    const reloadButton = document.getElementById("usuariosReloadButton");
+    const tableBody = document.getElementById("usuariosTableBody");
+
+    let usuarios = [];
+    let medicos = [];
+    let medicosMap = new Map();
+    let editingId = null;
+    let editingUsuario = null;
+
+    function showFeedback(element, message = "", tone) {
+        if (!element) {
+            return;
+        }
+
+        element.textContent = message;
+
+        if (!message) {
+            element.className = "";
+            return;
+        }
+
+        switch (tone) {
+            case "error":
+                element.className = "alert alert--error";
+                break;
+            case "success":
+                element.className = "alert alert--success";
+                break;
+            case "loading":
+                element.className = "loading";
+                break;
+            case "muted":
+                element.className = "text-subtle";
+                break;
+            default:
+                element.className = "alert";
+                break;
+        }
+    }
+
+    function renderMedicoOptions() {
+        const selectedValue = medicoSelect.value;
+        const options = ["<option value=\"\">Sin asignar</option>"];
+
+        medicos.forEach((medico) => {
+            const nombre = medico.nombreCompleto || buildNombreCompleto(medico);
+            options.push(`<option value="${medico.id}">${nombre}</option>`);
+        });
+
+        medicoSelect.innerHTML = options.join("");
+
+        if (selectedValue && medicoSelect.querySelector(`option[value="${selectedValue}"]`)) {
+            medicoSelect.value = selectedValue;
+        }
+    }
+
+    function renderUsuarios() {
+        if (!usuarios.length) {
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="6" class="empty-state">No hay usuarios registrados.</td>
+                </tr>
+            `;
+            return;
+        }
+
+        tableBody.innerHTML = usuarios
+            .map((usuario) => {
+                const medicoNombre = usuario.idMedico
+                    ? medicosMap.get(usuario.idMedico) || `ID ${usuario.idMedico}`
+                    : "Sin asignar";
+
+                const estado = usuario.activo ? "Activo" : "Inactivo";
+
+                return `
+                    <tr>
+                        <td>#${usuario.id}</td>
+                        <td>${usuario.correo}</td>
+                        <td>${usuario.nombreCompleto}</td>
+                        <td>${medicoNombre}</td>
+                        <td>${estado}</td>
+                        <td>
+                            <div class="table-actions">
+                                <button type="button" class="button button--sm" data-action="edit" data-id="${usuario.id}">Editar</button>
+                                <button type="button" class="button button--sm button--danger" data-action="delete" data-id="${usuario.id}">Eliminar</button>
+                            </div>
+                        </td>
+                    </tr>
+                `;
+            })
+            .join("");
+    }
+
+    function resetForm(options = {}) {
+        editingId = null;
+        editingUsuario = null;
+        form.reset();
+        activoCheckbox.checked = true;
+        formTitle.textContent = "Registrar usuario";
+        submitButton.textContent = "Registrar usuario";
+        cancelButton.hidden = true;
+
+        if (!options.keepFeedback) {
+            showFeedback(formFeedback);
+        }
+    }
+
+    async function loadMedicos() {
+        try {
+            medicos = await fetchJson(`${API_BASE}/medicos`);
+            medicosMap = new Map(
+                medicos.map((medico) => [medico.id, medico.nombreCompleto || buildNombreCompleto(medico)])
+            );
+            renderMedicoOptions();
+        } catch (error) {
+            showFeedback(formFeedback, `No se pudieron cargar los médicos: ${error.message}`, "error");
+        }
+    }
+
+    async function loadUsuarios() {
+        showFeedback(listFeedback, "Cargando usuarios...", "loading");
+
+        try {
+            usuarios = await fetchJson(`${API_BASE}/usuarios`);
+            renderUsuarios();
+            showFeedback(listFeedback);
+        } catch (error) {
+            usuarios = [];
+            tableBody.innerHTML = "";
+            showFeedback(listFeedback, error.message, "error");
+        }
+    }
+
+    function startEditing(usuario) {
+        editingId = usuario.id;
+        editingUsuario = usuario;
+
+        formTitle.textContent = `Editar usuario #${usuario.id}`;
+        submitButton.textContent = "Guardar cambios";
+        cancelButton.hidden = false;
+
+        correoInput.value = usuario.correo;
+        passwordInput.value = usuario.password;
+        nombreInput.value = usuario.nombreCompleto;
+        medicoSelect.value = usuario.idMedico?.toString() ?? "";
+        activoCheckbox.checked = usuario.activo;
+
+        showFeedback(formFeedback, "Modificando usuario seleccionado.", "muted");
+        form.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    tableBody.addEventListener("click", async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+
+        const action = target.dataset.action;
+        const id = Number(target.dataset.id);
+
+        if (!action || Number.isNaN(id)) {
+            return;
+        }
+
+        const usuario = usuarios.find((item) => item.id === id);
+        if (!usuario) {
+            return;
+        }
+
+        if (action === "edit") {
+            startEditing(usuario);
+            return;
+        }
+
+        if (action === "delete") {
+            const confirmed = window.confirm("¿Deseas eliminar este usuario?");
+            if (!confirmed) {
+                return;
+            }
+
+            try {
+                await fetchJson(`${API_BASE}/usuarios/${id}`, { method: "DELETE" });
+                await loadUsuarios();
+                if (editingId === id) {
+                    resetForm();
+                }
+                showFeedback(listFeedback, "El usuario se eliminó correctamente.", "success");
+            } catch (error) {
+                showFeedback(listFeedback, error.message, "error");
+            }
+        }
+    });
+
+    cancelButton.addEventListener("click", () => {
+        resetForm();
+    });
+
+    reloadButton.addEventListener("click", () => {
+        loadUsuarios();
+    });
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        showFeedback(formFeedback);
+
+        const correo = correoInput.value.trim();
+        const nombreCompleto = nombreInput.value.trim();
+        const passwordValue = passwordInput.value;
+        const finalPassword = passwordValue || editingUsuario?.password || "";
+
+        if (!correo || !nombreCompleto || !finalPassword) {
+            showFeedback(formFeedback, "Completa todos los campos obligatorios.", "error");
+            return;
+        }
+
+        const medicoValue = medicoSelect.value;
+
+        const payload = {
+            correo,
+            password: finalPassword,
+            nombreCompleto,
+            idMedico: medicoValue ? Number(medicoValue) : null,
+            activo: activoCheckbox.checked
+        };
+
+        const wasEditing = Boolean(editingId);
+        const url = wasEditing ? `${API_BASE}/usuarios/${editingId}` : `${API_BASE}/usuarios`;
+        const method = wasEditing ? "PUT" : "POST";
+
+        try {
+            await fetchJson(url, {
+                method,
+                body: JSON.stringify(payload)
+            });
+
+            await loadUsuarios();
+            resetForm({ keepFeedback: true });
+
+            const message = wasEditing
+                ? "El usuario se actualizó correctamente."
+                : "El usuario se registró correctamente.";
+
+            showFeedback(formFeedback, message, "success");
+        } catch (error) {
+            showFeedback(formFeedback, error.message, "error");
+        }
+    });
+
+    await loadMedicos();
+    await loadUsuarios();
+});

--- a/ProyectoCursoIA/wwwroot/medicos.html
+++ b/ProyectoCursoIA/wwwroot/medicos.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestión de médicos</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/medicos.js"></script>
+</head>
+<body class="app">
+    <header class="top-bar">
+        <h1>Prueba de CODEX</h1>
+        <nav>
+            <a class="button button--ghost" href="dashboard.html">Dashboard</a>
+            <a class="button button--ghost" href="usuarios.html">Usuarios</a>
+            <a class="button button--ghost" href="medicos.html">Médicos</a>
+            <a class="button button--ghost" href="pacientes.html">Pacientes</a>
+            <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        </nav>
+    </header>
+    <main class="content">
+        <section class="card card--narrow">
+            <h2 id="medicoFormTitle">Registrar médico</h2>
+            <p class="text-subtle">Completa la información para registrar o actualizar un médico.</p>
+            <form id="medicoForm" novalidate>
+                <p id="medicoFormFeedback"></p>
+                <label>
+                    Primer nombre
+                    <input type="text" name="primerNombre" id="medicoPrimerNombre" required />
+                </label>
+                <label>
+                    Segundo nombre
+                    <input type="text" name="segundoNombre" id="medicoSegundoNombre" />
+                </label>
+                <label>
+                    Apellido paterno
+                    <input type="text" name="apellidoPaterno" id="medicoApellidoPaterno" required />
+                </label>
+                <label>
+                    Apellido materno
+                    <input type="text" name="apellidoMaterno" id="medicoApellidoMaterno" />
+                </label>
+                <label>
+                    Cédula profesional
+                    <input type="text" name="cedula" id="medicoCedula" required />
+                </label>
+                <label>
+                    Teléfono
+                    <input type="tel" name="telefono" id="medicoTelefono" required />
+                </label>
+                <label>
+                    Especialidad
+                    <input type="text" name="especialidad" id="medicoEspecialidad" required />
+                </label>
+                <label>
+                    Correo electrónico
+                    <input type="email" name="email" id="medicoEmail" required />
+                </label>
+                <label class="checkbox">
+                    <input type="checkbox" name="activo" id="medicoActivo" checked />
+                    <span>Médico activo</span>
+                </label>
+                <div class="form__actions">
+                    <button type="submit" id="medicoSubmitButton">Registrar médico</button>
+                    <button type="button" id="medicoCancelButton" class="button button--ghost" hidden>Cancelar</button>
+                </div>
+            </form>
+        </section>
+        <section class="card">
+            <div class="card__header">
+                <h2>Médicos registrados</h2>
+                <button type="button" id="medicosReloadButton" class="button button--ghost">Actualizar lista</button>
+            </div>
+            <p id="medicosListFeedback"></p>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Especialidad</th>
+                        <th>Correo</th>
+                        <th>Teléfono</th>
+                        <th>Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody id="medicosTableBody">
+                    <tr>
+                        <td colspan="7" class="empty-state">Cargando médicos...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/ProyectoCursoIA/wwwroot/pacientes.html
+++ b/ProyectoCursoIA/wwwroot/pacientes.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestión de pacientes</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/pacientes.js"></script>
+</head>
+<body class="app">
+    <header class="top-bar">
+        <h1>Prueba de CODEX</h1>
+        <nav>
+            <a class="button button--ghost" href="dashboard.html">Dashboard</a>
+            <a class="button button--ghost" href="usuarios.html">Usuarios</a>
+            <a class="button button--ghost" href="medicos.html">Médicos</a>
+            <a class="button button--ghost" href="pacientes.html">Pacientes</a>
+            <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        </nav>
+    </header>
+    <main class="content">
+        <section class="card card--narrow">
+            <h2 id="pacienteFormTitle">Registrar paciente</h2>
+            <p class="text-subtle">Completa la información para registrar o actualizar un paciente.</p>
+            <form id="pacienteForm" novalidate>
+                <p id="pacienteFormFeedback"></p>
+                <label>
+                    Primer nombre
+                    <input type="text" name="primerNombre" id="pacientePrimerNombre" required />
+                </label>
+                <label>
+                    Segundo nombre
+                    <input type="text" name="segundoNombre" id="pacienteSegundoNombre" />
+                </label>
+                <label>
+                    Apellido paterno
+                    <input type="text" name="apellidoPaterno" id="pacienteApellidoPaterno" required />
+                </label>
+                <label>
+                    Apellido materno
+                    <input type="text" name="apellidoMaterno" id="pacienteApellidoMaterno" />
+                </label>
+                <label>
+                    Teléfono
+                    <input type="tel" name="telefono" id="pacienteTelefono" required />
+                </label>
+                <label class="checkbox">
+                    <input type="checkbox" name="activo" id="pacienteActivo" checked />
+                    <span>Paciente activo</span>
+                </label>
+                <div class="form__actions">
+                    <button type="submit" id="pacienteSubmitButton">Registrar paciente</button>
+                    <button type="button" id="pacienteCancelButton" class="button button--ghost" hidden>Cancelar</button>
+                </div>
+            </form>
+        </section>
+        <section class="card">
+            <div class="card__header">
+                <h2>Pacientes registrados</h2>
+                <button type="button" id="pacientesReloadButton" class="button button--ghost">Actualizar lista</button>
+            </div>
+            <p id="pacientesListFeedback"></p>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Teléfono</th>
+                        <th>Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody id="pacientesTableBody">
+                    <tr>
+                        <td colspan="5" class="empty-state">Cargando pacientes...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/ProyectoCursoIA/wwwroot/usuarios.html
+++ b/ProyectoCursoIA/wwwroot/usuarios.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestión de usuarios</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script defer src="js/common.js"></script>
+    <script defer src="js/usuarios.js"></script>
+</head>
+<body class="app">
+    <header class="top-bar">
+        <h1>Prueba de CODEX</h1>
+        <nav>
+            <a class="button button--ghost" href="dashboard.html">Dashboard</a>
+            <a class="button button--ghost" href="usuarios.html">Usuarios</a>
+            <a class="button button--ghost" href="medicos.html">Médicos</a>
+            <a class="button button--ghost" href="pacientes.html">Pacientes</a>
+            <button id="logoutButton" class="button button--ghost">Cerrar sesión</button>
+        </nav>
+    </header>
+    <main class="content">
+        <section class="card card--narrow">
+            <h2 id="usuarioFormTitle">Registrar usuario</h2>
+            <p class="text-subtle">Completa el formulario para agregar un nuevo usuario o edita uno existente.</p>
+            <form id="usuarioForm" novalidate>
+                <p id="usuarioFormFeedback"></p>
+                <label>
+                    Correo electrónico
+                    <input type="email" name="correo" id="usuarioCorreo" required />
+                </label>
+                <label>
+                    Contraseña
+                    <input type="password" name="password" id="usuarioPassword" required />
+                </label>
+                <label>
+                    Nombre completo
+                    <input type="text" name="nombreCompleto" id="usuarioNombreCompleto" required />
+                </label>
+                <label>
+                    Médico asociado
+                    <select name="idMedico" id="usuarioMedico">
+                        <option value="">Sin asignar</option>
+                    </select>
+                </label>
+                <label class="checkbox">
+                    <input type="checkbox" name="activo" id="usuarioActivo" checked />
+                    <span>Usuario activo</span>
+                </label>
+                <div class="form__actions">
+                    <button type="submit" id="usuarioSubmitButton">Registrar usuario</button>
+                    <button type="button" id="usuarioCancelButton" class="button button--ghost" hidden>Cancelar</button>
+                </div>
+            </form>
+        </section>
+        <section class="card">
+            <div class="card__header">
+                <h2>Usuarios registrados</h2>
+                <button type="button" id="usuariosReloadButton" class="button button--ghost">Actualizar lista</button>
+            </div>
+            <p id="usuariosListFeedback"></p>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Correo</th>
+                        <th>Nombre</th>
+                        <th>Médico</th>
+                        <th>Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody id="usuariosTableBody">
+                    <tr>
+                        <td colspan="6" class="empty-state">Cargando usuarios...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </main>
+    <footer class="footer">&copy; <span id="year"></span> Prueba de CODEX.</footer>
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated CRUD pages for usuarios, médicos y pacientes with forms, tables and navigation
- implement JavaScript controllers that consume the existing API endpoints for listing, creating, updating and deleting records
- extend shared styles and dashboard navigation to support the new CRUD views

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c2b9d9c8326b215ab794aebfa4f