### PR TITLE
Prevent exposing usuario passwords in API responses

### DIFF
--- a/ProyectoCursoIA.Tests/CustomWebApplicationFactory.cs
+++ b/ProyectoCursoIA.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProyectoCursoIA.Data;
+
+namespace ProyectoCursoIA.Tests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor is not null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseInMemoryDatabase("ProyectoCursoIA_Tests");
+            });
+
+            var sp = services.BuildServiceProvider();
+
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+}

--- a/ProyectoCursoIA.Tests/ProyectoCursoIA.Tests.csproj
+++ b/ProyectoCursoIA.Tests/ProyectoCursoIA.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoCursoIA\ProyectoCursoIA.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ProyectoCursoIA.Tests/UsuarioEndpointsTests.cs
+++ b/ProyectoCursoIA.Tests/UsuarioEndpointsTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ProyectoCursoIA.Data;
+using ProyectoCursoIA.Models;
+using Xunit;
+
+namespace ProyectoCursoIA.Tests;
+
+public class UsuarioEndpointsTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public UsuarioEndpointsTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetUsuarios_ShouldNotExposePassword()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+
+        db.Usuarios.Add(new Usuario
+        {
+            Correo = "correo@example.com",
+            Password = "Secreto123",
+            NombreCompleto = "Usuario Prueba",
+            Activo = true,
+            FechaCreacion = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var response = await _client.GetAsync("/api/usuarios");
+        response.EnsureSuccessStatusCode();
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var usuarios = document.RootElement;
+
+        Assert.True(usuarios.ValueKind == JsonValueKind.Array && usuarios.GetArrayLength() == 1);
+        var usuario = usuarios[0];
+
+        Assert.DoesNotContain(usuario.EnumerateObject(), p => string.Equals(p.Name, "Password", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PostUsuarios_ResponseShouldNotIncludePassword()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Database.EnsureDeleted();
+        db.Database.EnsureCreated();
+
+        var payload = new
+        {
+            correo = "nuevo@example.com",
+            password = "ClaveSegura1",
+            nombreCompleto = "Nuevo Usuario",
+            idMedico = (int?)null,
+            activo = true
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/usuarios", payload);
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var usuario = document.RootElement;
+
+        Assert.DoesNotContain(usuario.EnumerateObject(), p => string.Equals(p.Name, "Password", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/ProyectoCursoIA.sln
+++ b/ProyectoCursoIA.sln
@@ -1,25 +1,30 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35919.96 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoCursoIA", "ProyectoCursoIA\ProyectoCursoIA.csproj", "{21EA2155-C565-4F68-BBB6-B16A20C403B2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoCursoIA", "ProyectoCursoIA\\ProyectoCursoIA.csproj", "{21EA2155-C565-4F68-BBB6-B16A20C403B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoCursoIA.Tests", "ProyectoCursoIA.Tests\\ProyectoCursoIA.Tests.csproj", "{BCB5F5B5-0D8D-4A47-B47F-9D21F5FE9738}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{21EA2155-C565-4F68-BBB6-B16A20C403B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{21EA2155-C565-4F68-BBB6-B16A20C403B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{21EA2155-C565-4F68-BBB6-B16A20C403B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{21EA2155-C565-4F68-BBB6-B16A20C403B2}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {2D304566-E5EE-466C-8474-1C8ECD2178E3}
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {21EA2155-C565-4F68-BBB6-B16A20C403B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {21EA2155-C565-4F68-BBB6-B16A20C403B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {21EA2155-C565-4F68-BBB6-B16A20C403B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {21EA2155-C565-4F68-BBB6-B16A20C403B2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BCB5F5B5-0D8D-4A47-B47F-9D21F5FE9738}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BCB5F5B5-0D8D-4A47-B47F-9D21F5FE9738}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BCB5F5B5-0D8D-4A47-B47F-9D21F5FE9738}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BCB5F5B5-0D8D-4A47-B47F-9D21F5FE9738}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {2D304566-E5EE-466C-8474-1C8ECD2178E3}
+        EndGlobalSection
 EndGlobal

--- a/ProyectoCursoIA/Dtos/UsuarioDtos.cs
+++ b/ProyectoCursoIA/Dtos/UsuarioDtos.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ProyectoCursoIA.Dtos;
+
+public record UsuarioResponse(int Id, string Correo, string NombreCompleto, int? IdMedico, bool Activo, DateTime FechaCreacion);
+
+public record UsuarioCreateRequest(string Correo, string Password, string NombreCompleto, int? IdMedico, bool Activo);
+
+public record UsuarioUpdateRequest(string Correo, string NombreCompleto, int? IdMedico, bool Activo);


### PR DESCRIPTION
## Summary
- add dedicated DTOs for usuario create, update, and response models without the Password field
- update usuario endpoints to map entities to DTOs and return DTO payloads while keeping password updates separate
- introduce an integration test project that verifies usuario responses no longer expose passwords

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0566599f48326ab7af1dc8cb4b2c6